### PR TITLE
Added Unrestricted ExecutionPolicy to startup command

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,7 +28,7 @@ export function activate(context: vscode.ExtensionContext) {
 			return;
 		}
 		
-		var cmd = 'start powershell.exe -noexit -command \"cd \'' + vscode.workspace.rootPath + '\'\"';
+		var cmd = 'start powershell.exe -ExecutionPolicy UnRestricted  -noexit -command \"cd \'' + vscode.workspace.rootPath + '\'\"';
 		exec(cmd);
 	});
 	


### PR DESCRIPTION
Because I work on systems where the group policy doesn't allow me to permenantly alter the policy, it's easier to let the session have it's own  policy. Otherwise eveb my profile.ps1 fails to run at the start of this session...

You could use RemoteSigned or Bypass too... but I prefer this because ExecutionPolicy is not something we use in our environment
