### PR TITLE
Switch to the native (64bit) Powershell on 64bit Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Just look for the **Start PowerShell** command.
 _The PowerShell instance will be started using your system's default ExecutionPolicy, if you need an unrestricted shell use the **Start PowerShell (Unrestricted)** command._
 
 ##Changelog
+>* 0.3.0
+>  * Using the 64 bit version of Powershell on 64 bit Windows
 >* 0.2.1
 >  * Fixed a bug that prevented the use of the Unrestricted command until you started at least one normal instance
 >  * Added key bindings for both commands

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "codeshell",
 	"displayName": "CodeShell",
 	"description": "Start a new PowerShell window for the project folder",
-	"version": "0.2.2",
+	"version": "0.3.0",
 	"publisher": "Kipters",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
By default, 64 bit Windows will use 32 bit versions of system programs to ensure compatibility with older programs, or newer programs that still run in 32 bit, such as VS Code. Therefore, Codeshell will currently open a 32 bit PowerShell.

Unfortunately, not all PowerShell features are available in 32 bit. Especially PS Workflows are missing.

``` powershell
workflow test() { }
# Windows PowerShell Workflow is not supported in a Windows PowerShell x86-based console. Open a Windows PowerShell
# x64-based console, and then try again.
```

I've modified the Codeshell plugin in a way that it will run a 64 bit command line (if available) and start PowerShell from there.

I should probably warn you that this is my first experience with node.js. Please forgive me any beginners' mistakes.
